### PR TITLE
S: 车间管理 - 在 init_database.sql 中添加车间管理模块的数据库结构

### DIFF
--- a/database/init_database.sql
+++ b/database/init_database.sql
@@ -142,6 +142,124 @@ CREATE TABLE `bom_info` (
   CONSTRAINT `fk_bom_product` FOREIGN KEY (`product_id`) REFERENCES `material_info` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='BOM物料清单表';
 
+
+-- ========================================
+-- 车间管理模块表结构 (S成员负责)
+-- ========================================
+
+-- 车间信息表
+CREATE TABLE `workshop` (
+  `id` int NOT NULL AUTO_INCREMENT COMMENT '车间ID',
+  `workshop_code` varchar(50) NOT NULL COMMENT '车间编码',
+  `workshop_name` varchar(100) NOT NULL COMMENT '车间名称',
+  `manager_id` int DEFAULT NULL COMMENT '负责人ID',
+  `capacity` int DEFAULT NULL COMMENT '生产能力(件/天)',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：1-启用，0-禁用',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `create_user_id` int DEFAULT NULL COMMENT '创建人ID',
+  `create_user_name` varchar(100) DEFAULT NULL COMMENT '创建人姓名',
+  `update_time` datetime DEFAULT NULL COMMENT '更新时间',
+  `update_user_id` int DEFAULT NULL COMMENT '更新人ID',
+  `update_user_name` varchar(100) DEFAULT NULL COMMENT '更新人姓名',
+  `is_deleted` tinyint NOT NULL DEFAULT '0' COMMENT '是否删除：1-已删除，0-未删除',
+  `delete_time` datetime DEFAULT NULL COMMENT '删除时间',
+  `delete_user_id` int DEFAULT NULL COMMENT '删除人ID',
+  `delete_user_name` varchar(100) DEFAULT NULL COMMENT '删除人姓名',
+  `remark` text COMMENT '备注',
+  `version` int NOT NULL DEFAULT '1' COMMENT '版本号',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_workshop_code` (`workshop_code`),
+  KEY `idx_status` (`status`),
+  KEY `idx_is_deleted` (`is_deleted`),
+  CONSTRAINT `fk_workshop_manager` FOREIGN KEY (`manager_id`) REFERENCES `sys_user` (`id`),
+  CONSTRAINT `fk_workshop_create_user` FOREIGN KEY (`create_user_id`) REFERENCES `sys_user` (`id`),
+  CONSTRAINT `fk_workshop_update_user` FOREIGN KEY (`update_user_id`) REFERENCES `sys_user` (`id`),
+  CONSTRAINT `fk_workshop_delete_user` FOREIGN KEY (`delete_user_id`) REFERENCES `sys_user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='车间信息表';
+
+-- 在制品(WIP)表
+CREATE TABLE `wip` (
+  `id` int NOT NULL AUTO_INCREMENT COMMENT '在制品ID',
+  `order_id` int NOT NULL COMMENT '关联订单ID',
+-- wip 表中的 order_id 字段保留，但未添加外键约束，等待H成员完成生产订单表（production_order）后再补充。
+  `material_id` int NOT NULL COMMENT '物料ID',
+  `current_stage` varchar(50) DEFAULT NULL COMMENT '当前生产阶段',
+  `quantity` int NOT NULL COMMENT '数量',
+  `workshop_id` int NOT NULL COMMENT '所在车间ID',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：1-在制，2-等待，3-暂停，4-已完成',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `create_user_id` int DEFAULT NULL COMMENT '创建人ID',
+  `create_user_name` varchar(100) DEFAULT NULL COMMENT '创建人姓名',
+  `update_time` datetime DEFAULT NULL COMMENT '更新时间',
+  `update_user_id` int DEFAULT NULL COMMENT '更新人ID',
+  `update_user_name` varchar(100) DEFAULT NULL COMMENT '更新人姓名',
+  `is_deleted` tinyint NOT NULL DEFAULT '0' COMMENT '是否删除：1-已删除，0-未删除',
+  `delete_time` datetime DEFAULT NULL COMMENT '删除时间',
+  `delete_user_id` int DEFAULT NULL COMMENT '删除人ID',
+  `delete_user_name` varchar(100) DEFAULT NULL COMMENT '删除人姓名',
+  `remark` text COMMENT '备注',
+  `version` int NOT NULL DEFAULT '1' COMMENT '版本号',
+  PRIMARY KEY (`id`),
+  KEY `idx_order_id` (`order_id`),
+  KEY `idx_material_id` (`material_id`),
+  KEY `idx_workshop_id` (`workshop_id`),
+  KEY `idx_status` (`status`),
+  KEY `idx_is_deleted` (`is_deleted`),
+  CONSTRAINT `fk_wip_create_user` FOREIGN KEY (`create_user_id`) REFERENCES `sys_user` (`id`),
+  CONSTRAINT `fk_wip_update_user` FOREIGN KEY (`update_user_id`) REFERENCES `sys_user` (`id`),
+  CONSTRAINT `fk_wip_delete_user` FOREIGN KEY (`delete_user_id`) REFERENCES `sys_user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='在制品管理表';
+
+-- 设备信息表
+CREATE TABLE `equipment` (
+  `id` int NOT NULL AUTO_INCREMENT COMMENT '设备ID',
+  `equipment_code` varchar(50) NOT NULL COMMENT '设备编码',
+  `equipment_name` varchar(100) NOT NULL COMMENT '设备名称',
+  `equipment_type` varchar(50) DEFAULT NULL COMMENT '设备类型',
+  `workshop_id` int DEFAULT NULL COMMENT '所属车间ID',
+  `status` tinyint NOT NULL DEFAULT '1' COMMENT '状态：1-正常，2-维护中，3-故障，4-停用',
+  `last_maintenance_date` date DEFAULT NULL COMMENT '最后维护日期',
+  `next_maintenance_date` date DEFAULT NULL COMMENT '下次维护日期',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `create_user_id` int DEFAULT NULL COMMENT '创建人ID',
+  `create_user_name` varchar(100) DEFAULT NULL COMMENT '创建人姓名',
+  `update_time` datetime DEFAULT NULL COMMENT '更新时间',
+  `update_user_id` int DEFAULT NULL COMMENT '更新人ID',
+  `update_user_name` varchar(100) DEFAULT NULL COMMENT '更新人姓名',
+  `is_deleted` tinyint NOT NULL DEFAULT '0' COMMENT '是否删除：1-已删除，0-未删除',
+  `delete_time` datetime DEFAULT NULL COMMENT '删除时间',
+  `delete_user_id` int DEFAULT NULL COMMENT '删除人ID',
+  `delete_user_name` varchar(100) DEFAULT NULL COMMENT '删除人姓名',
+  `remark` text COMMENT '备注',
+  `version` int NOT NULL DEFAULT '1' COMMENT '版本号',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_equipment_code` (`equipment_code`),
+  KEY `idx_workshop_id` (`workshop_id`),
+  KEY `idx_status` (`status`),
+  KEY `idx_is_deleted` (`is_deleted`),
+  CONSTRAINT `fk_equipment_workshop` FOREIGN KEY (`workshop_id`) REFERENCES `workshop` (`id`),
+  CONSTRAINT `fk_equipment_create_user` FOREIGN KEY (`create_user_id`) REFERENCES `sys_user` (`id`),
+  CONSTRAINT `fk_equipment_update_user` FOREIGN KEY (`update_user_id`) REFERENCES `sys_user` (`id`),
+  CONSTRAINT `fk_equipment_delete_user` FOREIGN KEY (`delete_user_id`) REFERENCES `sys_user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='设备信息表';
+
+-- 设备状态历史表
+CREATE TABLE `equipment_status_history` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `equipment_id` int NOT NULL,
+  `old_status` tinyint NOT NULL,
+  `new_status` tinyint NOT NULL,
+  `change_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `change_user_id` int NOT NULL,
+  `remark` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_equipment_id` (`equipment_id`),
+  CONSTRAINT `fk_equipment_status_history_equipment` FOREIGN KEY (`equipment_id`) REFERENCES `equipment` (`id`),
+  CONSTRAINT `fk_equipment_status_history_user` FOREIGN KEY (`change_user_id`) REFERENCES `sys_user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='设备状态变更历史';
+
+
+
 -- 插入初始数据
 INSERT INTO `sys_user` (`user_code`, `user_name`, `login_name`, `password`, `department`, `position`, `create_user_name`) 
 VALUES 


### PR DESCRIPTION
- 添加了车间信息表、在制品表、设备信息表等表结构。
- 在制品表中的 order_id 字段已保留，但未添加外键约束，等待 H 成员完成生产订单表（production_order）后再补充。